### PR TITLE
Implement sticky sidebar suggested in #7

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -15,9 +15,11 @@ function MyApp({ Component, pageProps }: AppProps) {
       </Head>
       <NavBar pagePath={pagePath} />
       <div className="main-container">
-        <aside className="menu is-hidden-touch">
-          <FeaturesSideNav />
-        </aside>
+        <div className="sidenav-overflow">
+          <aside className="menu is-hidden-touch">
+            <FeaturesSideNav />
+          </aside>
+        </div>
         <main>
           <div className="container">
             <Component {...pageProps} />

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -11,7 +11,7 @@ $navbar-background-color: #fafafa;
 
 @media screen and (min-width: 1024px) {
   .sidenav-overflow {
-    overflow-x: scroll;
+    overflow-y: scroll;
     height: calc(100vh - 3.25rem);
     position: sticky;
     top: 0;

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -9,6 +9,15 @@ $navbar-background-color: #fafafa;
   font-weight: bolder;
 }
 
+@media screen and (min-width: 1024px) {
+  .sidenav-overflow {
+    overflow-x: scroll;
+    height: calc(100vh - 3.25rem);
+    position: sticky;
+    top: 0;
+  }
+}
+
 img.item-icon {
   width: 64px;
   height: 64px;


### PR DESCRIPTION
Wrapping the side menu in an overflow div so you can scroll independently.
This change only affects desktop, mobile will function the same :)

Does look slightly strange without the top bar being fixed too, but I think its a good change!