### PR TITLE
Mention the level emitter no longer requires a channel

### DIFF
--- a/content/features/me-network/network-functions/me-level-emitter.md
+++ b/content/features/me-network/network-functions/me-level-emitter.md
@@ -15,8 +15,8 @@ level. You can set the threshold and if the <ItemLink
 id="level_emitter"/> will emit a redstone signal
 or turn it off.
 
-Requires a [channel](../channels.md) to function, if its power or
-channel is lost the emitter will switch to an off state.
+Does not require a [channel](../channels.md) to function,
+if its power is lost the emitter will switch to an off state.
 
 These can tap into the crafting system when a crafting card is installed,
 allowing you to output redstone while an item is being crafted, or even


### PR DESCRIPTION
e6da0db8cf15d05716c5c89f15b5f6516454a1af